### PR TITLE
Adds Modes to MQTT

### DIFF
--- a/web/src/components/ChatComponent.tsx
+++ b/web/src/components/ChatComponent.tsx
@@ -1,90 +1,90 @@
 import { useState, useRef, useEffect } from "react";
 import "./ChatComponent.css";
-import useMQTT from "../mqtt";
+import useMQTT, { MQTTMode } from "../mqtt";
 
 //in order to make this work, we need to but <ChatComponent /> in App.tsx
 
 type Message = {
-  text: string;
-  sender: string;
-  timestamp: string;
+	text: string;
+	sender: string;
+	timestamp: string;
 };
 
 const ChatComponent = () => {
-  const [newMessage, setNewMessage] = useState("");
-  const [isMinimized, setIsMinimized] = useState(false);
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+	const [newMessage, setNewMessage] = useState("");
+	const [isMinimized, setIsMinimized] = useState(false);
+	const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
-  // Connect to MQTT broker
-  const { messages, sendMessage, error, connected } = useMQTT<Message>("chat");
+	// Connect to MQTT broker
+	const { messages, sendMessage, error, connected } = useMQTT<Message>("chat", {
+		mode: MQTTMode.BUFFERED,
+		bufferSize: 5, // How long do we want this to be?
+	});
 
-  const sendMessageEvent = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!newMessage.trim()) return;
+	// // Auto-scroll to bottom when new messages arrive
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
 
-    const messageData = {
-      text: newMessage,
-      sender: `User_${Math.random().toString(16).substring(2, 6)}`, // once available use actual user profile/ID
-      timestamp: new Date().toISOString(),
-    };
+	const sendMessageEvent = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		if (!newMessage.trim()) return;
 
-    sendMessage(messageData);
-    setNewMessage("");
-  };
+		const messageData = {
+			text: newMessage,
+			sender: `User_${Math.random().toString(16).substring(2, 6)}`, // once available use actual user profile/ID
+			timestamp: new Date().toISOString(),
+		};
 
-  const toggleMinimize = () => {
-    setIsMinimized(!isMinimized);
-  };
+		sendMessage(messageData);
+		setNewMessage("");
+	};
 
-  useEffect(() => {
-    console.log("last message:", messages[messages.length - 1]);
-  }, [messages]);
+	const toggleMinimize = () => {
+		setIsMinimized(!isMinimized);
+	};
 
-  return (
-    <div className={`chat-widget ${isMinimized ? "minimized" : ""}`}>
-      <div className="chat-container">
-        <div className="chat-header" onClick={toggleMinimize}>
-          <h3>
-            Chat {!connected && " (Disconnected)"}
-            {error && ` - ${error.message}`}
-          </h3>
-          <button className="minimize-button">{isMinimized ? "+" : "-"}</button>
-        </div>
+	return (
+		<div className={`chat-widget ${isMinimized ? "minimized" : ""}`}>
+			<div className="chat-container">
+				<div className="chat-header" onClick={toggleMinimize}>
+					<h3>
+						Chat {!connected && " (Disconnected)"}
+						{error && ` - ${error.message}`}
+					</h3>
+					<button className="minimize-button">{isMinimized ? "+" : "-"}</button>
+				</div>
 
-        {!isMinimized && (
-          <>
-            <div className="chat-messages">
-              {messages.map((msg, index) => (
-                <div key={index} className="message">
-                  <span className="sender">{msg.sender}</span>
-                  <span className="text">{msg.text}</span>
-                  <span className="timestamp">
-                    {new Date(msg.timestamp).toLocaleTimeString()}
-                  </span>
-                </div>
-              ))}
-              <div ref={messagesEndRef} />
-            </div>
+				{!isMinimized && (
+					<>
+						<div className="chat-messages">
+							{messages.map((msg, index) => (
+								<div key={index} className="message">
+									<span className="sender">{msg.sender}</span>
+									<span className="text">{msg.text}</span>
+									<span className="timestamp">{new Date(msg.timestamp).toLocaleTimeString()}</span>
+								</div>
+							))}
+							<div ref={messagesEndRef} />
+						</div>
 
-            <form onSubmit={sendMessageEvent} className="chat-input-form">
-              <input
-                type="text"
-                value={newMessage}
-                onChange={(e) => setNewMessage(e.target.value)}
-                placeholder={
-                  connected ? "Type your message..." : "Connecting..."
-                }
-                disabled={!connected}
-              />
-              <button type="submit" disabled={!connected || !newMessage.trim()}>
-                Send
-              </button>
-            </form>
-          </>
-        )}
-      </div>
-    </div>
-  );
+						<form onSubmit={sendMessageEvent} className="chat-input-form">
+							<input
+								type="text"
+								value={newMessage}
+								onChange={(e) => setNewMessage(e.target.value)}
+								placeholder={connected ? "Type your message..." : "Connecting..."}
+								disabled={!connected}
+							/>
+							<button type="submit" disabled={!connected || !newMessage.trim()}>
+								Send
+							</button>
+						</form>
+					</>
+				)}
+			</div>
+		</div>
+	);
 };
 
 export default ChatComponent;

--- a/web/src/mqtt.tsx
+++ b/web/src/mqtt.tsx
@@ -2,77 +2,217 @@ import mqtt, { MqttClient } from "mqtt";
 import { useEffect, useState } from "react";
 
 interface UseMQTT<T> {
-  messages: T[];
-  sendMessage: (message: T) => void;
-  error: Error | null;
-  connected: boolean;
+	messages: T[];
+	sendMessage: (message: T) => void;
+	error: Error | null;
+	connected: boolean;
 }
 
-const useMQTT = <T,>(topic: string): UseMQTT<T> => {
-  const [client, setClient] = useState<MqttClient | null>(null);
-  const [messages, setMessages] = useState<T[]>([]);
-  const [error, setError] = useState<Error | null>(null);
-  const [connected, setConnected] = useState(false);
+enum MQTTMode {
+	SINGLE = "single",
+	BUFFERED = "buffered",
+}
 
-  useEffect(() => {
-    // This should eventually be tied to the user's profile/id
-    const clientId = "webchat_" + Math.random().toString(16).substring(2, 8);
+interface SingleModeOptions<T> {
+	mode: MQTTMode.SINGLE;
+	orderBy?: (a: T, b: T) => number;
+}
 
-    const mqttClient = mqtt.connect("wss://test.mosquitto.org:8081", {
-      clientId: clientId,
-      clean: true,
-      connectTimeout: 4000,
-      reconnectPeriod: 1000,
-    });
+interface BufferedModeOptions<T> {
+	mode: MQTTMode.BUFFERED;
+	bufferSize: number;
+	existingMessages?: T[];
+	orderBy?: (a: T, b: T) => number;
+}
 
-    mqttClient.on("connect", () => {
-      setConnected(true);
-      setError(null);
-      mqttClient.subscribe(`IS5700/USU/McMullin/${topic}`);
-      console.log(
-        `Connected to MQTT Broker: host: test.mosquitto.org, port: 8081, topic: IS5700/USU/McMullin/${topic}`
-      );
-    });
+type UseMQTTOptions<T> = SingleModeOptions<T> | BufferedModeOptions<T>;
 
-    mqttClient.on("message", (_, message) => {
-      let parsedMessage: T;
-      const messageString = message.toString();
-      try {
-        parsedMessage = JSON.parse(messageString) as T;
-      } catch (error) {
-        console.error("Failed to parse message:", error);
-        return;
-      }
-      setMessages((prevMessages) => [...prevMessages, parsedMessage]);
-    });
+/**
+ * Custom hook to manage MQTT connections and messages.
+ *
+ * @template T - The type of the messages.
+ * @param {string} topic - The MQTT topic to subscribe to.
+ * @param {UseMQTTOptions<T>} options - Options for configuring the MQTT connection and message handling.See `UseMQTTOptions`. Defaults to SINGLE mode.
+ * @returns {UseMQTT<T>} An object containing the messages, sendMessage function, error, and connection status.
+ *
+ * @typedef {Object} UseMQTTOptions<T>
+ * @property {MQTTMode} mode - The mode of message handling (SINGLE or BUFFERED).
+ * @property {number} [bufferSize] - The size of the message buffer (only applicable in BUFFERED mode).
+ * @property {T[]} [existingMessages] - Existing messages to initialize the messages array with (only applicable in BUFFERED mode). This also immediately pusbishes these messages to the MQTT topic.
+ *
+ * @typedef {Object} UseMQTT<T>
+ * @property {T[]} messages - The list of messages.
+ * @property {(message: T) => void} sendMessage - Function to send a message on the topic.
+ * @property {Error | null} error - The error object if an error occurs, otherwise null.
+ * @property {boolean} connected - The connection status.
+ *
+ * @typedef {Object} MqttClient - The MQTT client instance.
+ *
+ * @typedef {Object} Mode
+ * @property {string} SINGLE - Single message mode.
+ * @property {string} BUFFERED - Buffered message mode.
+ *
+ * @param {MqttClient} mqttClient - The MQTT client instance.
+ * @param {React.Dispatch<React.SetStateAction<T[]>>} setMessages - Function to update the messages state.
+ * @param {keyof T | ((a: T, b: T) => number)} [orderBy] - Optional parameter to sort messages by a key or a custom function.
+ * @param {number} bufferSize - The size of the message buffer.
+ * @param {T[]} existingMessages - Existing messages to initialize the messages array with (only applicable in BUFFERED mode). This also immediately publishes these messages to the MQTT topic.
+ *
+ * @returns {void}
+ */
+const useMQTT = <T,>(
+	topic: string,
+	options: UseMQTTOptions<T> = { mode: MQTTMode.SINGLE }
+): UseMQTT<T> => {
+	const [client, setClient] = useState<MqttClient | null>(null);
+	const [messages, setMessages] = useState<T[]>(
+		options.mode === MQTTMode.BUFFERED && options.existingMessages ? options.existingMessages : []
+	);
+	const [error, setError] = useState<Error | null>(null);
+	const [connected, setConnected] = useState(false);
 
-    mqttClient.on("error", (err) => {
-      console.error("MQTT error:", err.message);
-      setError(Error(err.message));
-      setConnected(false);
-    });
+	useEffect(() => {
+		const mqttClient = mqtt.connect("wss://test.mosquitto.org:8081", {
+			clientId: `webchat_${Math.random().toString(16).substring(2, 8)}`, // This will be the user id
+			clean: true,
+			connectTimeout: 4000,
+			reconnectPeriod: 1000,
+		});
 
-    mqttClient.on("offline", () => {
-      setConnected(false);
-      setError(Error("Connection lost. Reconnecting..."));
-    });
+		mqttClient.on("connect", () => {
+			setConnected(true);
+			setError(null);
+			mqttClient.subscribe(`IS5700/USU/McMullin/${topic}`);
+			console.log(`Connected to topic: ${topic}`);
+		});
 
-    setClient(mqttClient);
+		mqttClient.on("error", (err) => {
+			setError(Error(`MQTT error: ${err.message}`));
+			setConnected(false);
+		});
 
-    return () => {
-      mqttClient.end();
-    };
-  }, [topic]);
+		mqttClient.on("offline", () => {
+			setConnected(false);
+			setError(Error("Connection lost. Reconnecting..."));
+		});
 
-  const sendMessage = (message: T) => {
-    if (client) {
-      const messageString =
-        typeof message === "string" ? message : JSON.stringify(message);
-      client.publish(`IS5700/USU/McMullin/${topic}`, messageString);
-    }
-  };
+		setClient(mqttClient);
 
-  return { messages, sendMessage, error, connected };
+		if (options.mode === MQTTMode.SINGLE) {
+			useSingleMessageMode(mqttClient, setMessages);
+		} else if (options.mode === MQTTMode.BUFFERED) {
+			useBufferedMode(
+				mqttClient,
+				options.bufferSize,
+				options.existingMessages ?? [],
+				setMessages,
+				options.orderBy
+			);
+		}
+
+		return () => {
+			mqttClient.end();
+		};
+	}, [topic]);
+
+	const sendMessage = (message: T) => {
+		sendMessageForMode(options.mode, message);
+	};
+
+	const sendMessageForMode = (mode: MQTTMode, message: T) => {
+		switch (mode) {
+			case MQTTMode.SINGLE:
+				if (client) {
+					const messageString = JSON.stringify(message);
+					client.publish(`IS5700/USU/McMullin/${topic}`, messageString);
+				}
+				break;
+			case MQTTMode.BUFFERED:
+				const bufferedOptions = options as BufferedModeOptions<T>;
+				if (client) {
+					const updatedMessages = [...messages, message];
+					const bufferMessages = updatedMessages.slice(-bufferedOptions.bufferSize);
+
+					client.publish(`IS5700/USU/McMullin/${topic}`, JSON.stringify(bufferMessages), {
+						retain: true,
+					});
+				}
+				break;
+		}
+	};
+
+	const sortMessages = <T,>(messages: T[], orderBy?: (a: T, b: T) => number) => {
+		console.log("Sorting messages", orderBy);
+		if (!orderBy) return messages;
+		return messages.sort(orderBy);
+	};
+
+	const useSingleMessageMode = <T,>(
+		mqttClient: MqttClient,
+		setMessages: React.Dispatch<React.SetStateAction<T[]>>,
+		orderBy?: (a: T, b: T) => number
+	) => {
+		mqttClient.on("message", (_, message) => {
+			let parsedMessage: T;
+			try {
+				parsedMessage = JSON.parse(message.toString()) as T;
+			} catch (error) {
+				console.error("Failed to parse single message:", error);
+				return;
+			}
+
+			setMessages((prevMessages) => sortMessages([...prevMessages, parsedMessage], orderBy));
+		});
+	};
+
+	const useBufferedMode = <T,>(
+		mqttClient: MqttClient,
+		bufferSize: number,
+		existingMessages: T[],
+		setMessages: React.Dispatch<React.SetStateAction<T[]>>,
+		orderBy?: (a: T, b: T) => number
+	) => {
+		// Helper to remove duplicates
+		const filterDuplicates = (newMessages: T[], existingMessages: T[]): T[] => {
+			const existingMessageSet = new Set(existingMessages.map((msg) => JSON.stringify(msg)));
+			return newMessages.filter((msg) => !existingMessageSet.has(JSON.stringify(msg)));
+		};
+
+		// Handle message event
+		mqttClient.on("message", (_, message) => {
+			console.log("Message received:", message.toString());
+
+			try {
+				// Parse the entire array of messages from the received JSON string
+				const parsedMessages = JSON.parse(message.toString()) as T[];
+				if (!Array.isArray(parsedMessages)) {
+					console.error("Parsed message is not an array:", parsedMessages);
+					return; // Exit early if parsedMessages is not an array
+				}
+
+				// Filter out duplicates using current messages in state
+				setMessages((prevMessages) => {
+					const filteredMessages = filterDuplicates(parsedMessages, prevMessages);
+					return sortMessages([...prevMessages, ...filteredMessages], orderBy);
+				});
+			} catch (error) {
+				console.error("Failed to parse buffered message array:", error);
+			}
+		});
+
+		// Publish "catch-up" messages on connect
+		mqttClient.on("connect", () => {
+			if (existingMessages.length > 0) {
+				const bufferMessages = existingMessages.slice(-bufferSize);
+				mqttClient.publish(`IS5700/USU/McMullin/${topic}`, JSON.stringify(bufferMessages), {
+					retain: true,
+				});
+			}
+		});
+	};
+
+	return { messages, sendMessage, error, connected };
 };
 
+export { MQTTMode };
 export default useMQTT;


### PR DESCRIPTION
This commit adds modes to MQTT.

Modes include single and buffered. 

Buffered mode keeps tracks of a buffer of messages and manages your message array for you. Each message sent will contain the number of messages in the buffer, and then - when received - have duplicates removed before updating the messages array. 

this will be used with chat features for catching up on a conversation joined mid-way through. But can also be used in other contexts like maybe game management? 🤷 

